### PR TITLE
Fix fn level secrets

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -29,9 +29,9 @@ function init (config) {
 function load (options) {
   init()
   const mergedOptions = Object.assign({}, secrets.options, options)
-  const environmentSecrets = Object.assign({}, secrets.environments.$global, secrets.environments[process.env._HANDLER.split('.')[1]])
-  const parameterNames = _.uniq(_.values(environmentSecrets))
   const provider = getStorageProvider(mergedOptions)
+  const environmentSecrets = Object.assign({}, secrets.environments.$global, secrets.environments[provider.getFunctionName()])
+  const parameterNames = _.uniq(_.values(environmentSecrets))
   return provider.getSecret(parameterNames).then(data => {
     const missingParameters = parameterNames.filter(expected => !_.keys(data).some(received => expected === received))
     Object.assign(process.env, _.mapValues(environmentSecrets, key => data[key]))

--- a/lib/providers/aws.js
+++ b/lib/providers/aws.js
@@ -70,10 +70,15 @@ module.exports = function (options) {
     })
   }
 
+  function getFunctionName() {
+    return process.env.AWS_LAMBDA_FUNCTION_NAME
+  }
+
   return {
     getSecret,
     setSecret,
     deleteSecret,
-    listSecrets
+    listSecrets,
+    getFunctionName
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "serverless-secrets",
-  "version": "3.0.0-beta.11",
+  "name": "@tabordasolutions/serverless-secrets",
+  "version": "3.0.0-beta.12",
   "description": "A serverless plugin for managing secrets",
   "main": "plugin/index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/trek10inc/serverless-secrets"
+    "url": "https://github.com/tabordasolutions/serverless-secrets"
   },
   "keywords": [
     "serverless",
@@ -21,12 +21,12 @@
     "parameter store",
     "env"
   ],
-  "author": "Jared Short <jshort@trek10.com> (https://www.trek10.com)",
+  "author": "Sneha Nagole <sneha.nagole@tabordasolutions.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/trek10inc/serverless-secrets/issues"
   },
-  "homepage": "https://github.com/trek10inc/serverless-secrets",
+  "homepage": "https://github.com/tabordasolutions/serverless-secrets",
   "dependencies": {
     "lodash": "^4.17.4"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tabordasolutions/serverless-secrets"
+    "url": "https://github.com/trek10inc/serverless-secrets"
   },
   "keywords": [
     "serverless",
@@ -21,12 +21,12 @@
     "parameter store",
     "env"
   ],
-  "author": "Sneha Nagole <sneha.nagole@tabordasolutions.com>",
+  "author": "Jared Short <jshort@trek10.com> (https://www.trek10.com)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/trek10inc/serverless-secrets/issues"
   },
-  "homepage": "https://github.com/tabordasolutions/serverless-secrets",
+  "homepage": "https://github.com/trek10inc/serverless-secrets",
   "dependencies": {
     "lodash": "^4.17.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secrets",
-  "version": "3.0.0-beta.12",
+  "version": "3.0.0-beta.11",
   "description": "A serverless plugin for managing secrets",
   "main": "plugin/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tabordasolutions/serverless-secrets",
+  "name": "serverless-secrets",
   "version": "3.0.0-beta.12",
   "description": "A serverless plugin for managing secrets",
   "main": "plugin/index.js",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -216,25 +216,25 @@ class ServerlessSecrets {
   }
 
   generateConfig () {
-      this.serverless.cli.log('Generating Serverless Secrets Config options')
-      if (!this.serverless.service.provider.name) {
-          throw new Error('No provider name configured in serverless.yml')
-      }
+    this.serverless.cli.log('Generating Serverless Secrets Config options')
+    if (!this.serverless.service.provider.name) {
+      throw new Error('No provider name configured in serverless.yml')
+    }
 
-      // build options object
-      const options = Object.assign(
-          {
-              throwOnMissingSecret: false,
-              logOnMissingSecret: true,
-              skipValidation: false,
-              omitPermissions: false,
-              resourceForIamRole: '*'
-          },
-          _.get(this.serverless.service, 'custom.serverlessSecrets', {}),
-          {
-              provider: this.serverless.service.provider.name
-          }
-      )
+    // build options object
+    const options = Object.assign(
+      {
+        throwOnMissingSecret: false,
+        logOnMissingSecret: true,
+        skipValidation: false,
+        omitPermissions: false,
+        resourceForIamRole: '*'
+      },
+      _.get(this.serverless.service, 'custom.serverlessSecrets', {}),
+      {
+        provider: this.serverless.service.provider.name
+      }
+    )
 
       return {
           options
@@ -246,23 +246,23 @@ class ServerlessSecrets {
   }
 
   generateEnvironmentConfig () {
-      this.serverless.cli.log('Generating Serverless Secrets Config environments')
-      const functions = this.serverless.service.functions
-      const environments = Object.keys(functions)
-          .reduce((environments, key) => {
-              const functionName = functions[key].name || [this.serverless.service.service, this.serverless.processedInput.options.stage, key].join('-')
-              if (functions[key].environmentSecrets) {
-                  environments[functionName] = functions[key].environmentSecrets
-              }
-              return environments
-          }, {})
+    this.serverless.cli.log('Generating Serverless Secrets Config environments')
+    const functions = this.serverless.service.functions
+    const environments = Object.keys(functions)
+      .reduce((environments, key) => {
+        const functionName = functions[key].name || [this.serverless.service.service, this.serverless.processedInput.options.stage, key].join('-')
+        if (functions[key].environmentSecrets) {
+          environments[functionName] = functions[key].environmentSecrets
+        }
+        return environments
+      }, {})
 
-      environments.$global = this.serverless.service.provider.environmentSecrets || {}
+    environments.$global = this.serverless.service.provider.environmentSecrets || {}
 
-      return environments;
+    return environments
   }
 
-    writeConfigFile () {
+  writeConfigFile () {
     this.serverless.cli.log(`Writing ${constants.CONFIG_FILE_NAME}`)
     fs.writeFileSync(constants.CONFIG_FILE_NAME, JSON.stringify(this.config))
   }


### PR DESCRIPTION
##What is changed
1. Common Function level secrets are resolved correctly without being overridden by the last function level secret.
2. Serverless resolves variables after plugins are loaded. This is causing an issue when function configuration uses variables (file imports or simple variables). As a fix, re-initializing configuration after Serverless resolves the variables in Serverless config file.

We can improve the solution by splitting config.options & config.environments into separate variables. I am planning to make that change when we propose a PR on the trek10inc serverless-secrets repo.